### PR TITLE
Custom compare support for the If methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ $client = new Aternos\Etcd\Client("localhost:2379", "username", "password");
 $client->put("key", "value");
 $client->get("key");
 $client->delete("key");
-$client->putIf("key", "newValue", "expectedPreviousValue");
-$client->deleteIf("key", "expectedPreviousValue");
+$client->putIf("key", "newValue", "valueToCompareWith", "=", Etcdserverpb\Compare\CompareTarget::VALUE);
+$client->deleteIf("key", "3", ">", Etcdserverpb\Compare\CompareTarget::VERSION);
 ```
 
 #### Sharded client

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ $client = new Aternos\Etcd\Client("localhost:2379", "username", "password");
 $client->put("key", "value");
 $client->get("key");
 $client->delete("key");
-$client->putIf("key", "newValue", "valueToCompareWith", false, \Etcdserverpb\Compare\CompareResult::EQUAL, Etcdserverpb\Compare\CompareTarget::VALUE);
-$client->deleteIf("key", "3", false, \Etcdserverpb\Compare\CompareResult::GREATER, Etcdserverpb\Compare\CompareTarget::VERSION);
+$client->putIf("key", "newValue", "valueToCompareWith");
+$client->deleteIf("key", "3");
 ```
 
 #### Sharded client

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ $client = new Aternos\Etcd\Client("localhost:2379", "username", "password");
 $client->put("key", "value");
 $client->get("key");
 $client->delete("key");
-$client->putIf("key", "newValue", "valueToCompareWith", "=", Etcdserverpb\Compare\CompareTarget::VALUE);
-$client->deleteIf("key", "3", ">", Etcdserverpb\Compare\CompareTarget::VERSION);
+$client->putIf("key", "newValue", "valueToCompareWith", false, \Etcdserverpb\Compare\CompareResult::EQUAL, Etcdserverpb\Compare\CompareTarget::VALUE);
+$client->deleteIf("key", "3", false, \Etcdserverpb\Compare\CompareResult::GREATER, Etcdserverpb\Compare\CompareTarget::VERSION);
 ```
 
 #### Sharded client

--- a/src/Client.php
+++ b/src/Client.php
@@ -273,6 +273,26 @@ class Client implements ClientInterface
     }
 
     /**
+     * Get an instance of Compare
+     *
+     * @param string $key
+     * @param string $value
+     * @param int $result see CompareResult class for available constants
+     * @param int $target check constants in the CompareTarget class for available values
+     * @return Compare
+     */
+    public function getCompare(string $key, string $value, int $result, int $target): Compare
+    {
+        $compare = new Compare();
+        $compare->setKey($key);
+        $compare->setValue($value);
+        $compare->setTarget($target);
+        $compare->setResult($result);
+
+        return $compare;
+    }
+
+    /**
      * Get an instance of KVClient
      *
      * @return KVClient
@@ -304,25 +324,6 @@ class Client implements ClientInterface
         return $this->authClient;
     }
 
-    /**
-     * Get an instance of Compare
-     *
-     * @param string $key
-     * @param string $value
-     * @param int $result see CompareResult class for available constants
-     * @param int $target check constants in the CompareTarget class for available values
-     * @return Compare
-     */
-    protected function getCompare(string $key, string $value, int $result, int $target): Compare
-    {
-        $compare = new Compare();
-        $compare->setKey($key);
-        $compare->setValue($value);
-        $compare->setTarget($target);
-        $compare->setResult($result);
-
-        return $compare;
-    }
 
     /**
      * Get an authentication token

--- a/src/Client.php
+++ b/src/Client.php
@@ -191,7 +191,7 @@ class Client implements ClientInterface
         $operation = $this->getPutOperation($key, $value);
         $compare = $this->getCompareForIf($key, $compareValue);
 
-        return $this->requestIf($key, $operation, $compare, $returnNewValueOnFail);
+        return $this->requestIf($key, [$operation], [$compare], $returnNewValueOnFail);
     }
 
     /**
@@ -209,26 +209,26 @@ class Client implements ClientInterface
         $operation = $this->getDeleteOperation($key);
         $compare = $this->getCompareForIf($key, $compareValue);
 
-        return $this->requestIf($key, $operation, $compare, $returnNewValueOnFail);
+        return $this->requestIf($key, [$operation], [$compare], $returnNewValueOnFail);
     }
 
     /**
      * Execute $requestOperation if $key value matches $previous otherwise $returnNewValueOnFail
      *
      * @param string $key
-     * @param RequestOp $requestOperation
-     * @param Compare $compare
+     * @param array $requestOperations array of RequestOp objects
+     * @param array $compare array of Compare objects
      * @param bool $returnNewValueOnFail
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      */
-    public function requestIf(string $key, RequestOp $requestOperation, Compare $compare, bool $returnNewValueOnFail = false)
+    public function requestIf(string $key, array $requestOperations, array $compare, bool $returnNewValueOnFail = false)
     {
         $client = $this->getKvClient();
 
         $request = new TxnRequest();
-        $request->setCompare([$compare]);
-        $request->setSuccess([$requestOperation]);
+        $request->setCompare($compare);
+        $request->setSuccess($requestOperations);
 
         if ($returnNewValueOnFail) {
             $getRequest = new RangeRequest();

--- a/src/Client.php
+++ b/src/Client.php
@@ -181,7 +181,7 @@ class Client implements ClientInterface
      * @throws InvalidResponseStatusCodeException
      * @throws \Exception
      */
-    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
+    public function putIf(string $key, string $value, string $compareValue, bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
     {
         $request = new PutRequest();
         $request->setKey($key);
@@ -207,7 +207,7 @@ class Client implements ClientInterface
      * @throws InvalidResponseStatusCodeException
      * @throws \Exception
      */
-    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
+    public function deleteIf(string $key, string $compareValue, bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
     {
         $request = new DeleteRangeRequest();
         $request->setKey($key);

--- a/src/Client.php
+++ b/src/Client.php
@@ -175,13 +175,13 @@ class Client implements ClientInterface
      * @param string $value The new value to set
      * @param string $compareValue The previous value to compare against
      * @param bool $returnNewValueOnFail
-     * @param string $compareOp can be '=', '!=', '>', '<'
+     * @param int $compareOp see CompareResult class for available constants
      * @param int $compareTarget check constants in the CompareTarget class for available values
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      * @throws \Exception
      */
-    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE)
+    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
     {
         $request = new PutRequest();
         $request->setKey($key);
@@ -201,13 +201,13 @@ class Client implements ClientInterface
      * @param string $key
      * @param string $compareValue The previous value to compare against
      * @param bool $returnNewValueOnFail
-     * @param string $compareOp can be '=', '!=', '>', '<'
+     * @param int $compareOp see CompareResult class for available constants
      * @param int $compareTarget check constants in the CompareTarget class for available values
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      * @throws \Exception
      */
-    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE)
+    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
     {
         $request = new DeleteRangeRequest();
         $request->setKey($key);
@@ -306,35 +306,17 @@ class Client implements ClientInterface
      *
      * @param string $key
      * @param string $value
-     * @param string $result resultOp, can be '=', '!=', '>', '<'
+     * @param int $result see CompareResult class for available constants
      * @param int $target check constants in the CompareTarget class for available values
      * @return Compare
-     * @throws \Exception
      */
-    protected function getCompare(string $key, string $value, string $result, int $target): Compare
+    protected function getCompare(string $key, string $value, int $result, int $target): Compare
     {
-        switch ($result) {
-            case '=':
-                $cmpResult = CompareResult::EQUAL;
-                break;
-            case '!=':
-                $cmpResult = CompareResult::NOT_EQUAL;
-                break;
-            case '>':
-                $cmpResult = CompareResult::GREATER;
-                break;
-            case '<':
-                $cmpResult = CompareResult::LESS;
-                break;
-            default:
-                throw new \Exception('Unknown result op');
-        }
-
         $compare = new Compare();
         $compare->setKey($key);
         $compare->setValue($value);
         $compare->setTarget($target);
-        $compare->setResult($cmpResult);
+        $compare->setResult($result);
 
         return $compare;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -188,13 +188,7 @@ class Client implements ClientInterface
      */
     public function putIf(string $key, string $value, $compareValue, bool $returnNewValueOnFail = false)
     {
-        $request = new PutRequest();
-        $request->setKey($key);
-        $request->setValue($value);
-
-        $operation = new RequestOp();
-        $operation->setRequestPut($request);
-
+        $operation = $this->getPutOperation($key, $value);
         $compare = $this->getCompareForIf($key, $compareValue);
 
         return $this->requestIf($key, $operation, $compare, $returnNewValueOnFail);
@@ -212,12 +206,7 @@ class Client implements ClientInterface
      */
     public function deleteIf(string $key, $compareValue, bool $returnNewValueOnFail = false)
     {
-        $request = new DeleteRangeRequest();
-        $request->setKey($key);
-
-        $operation = new RequestOp();
-        $operation->setRequestDeleteRange($request);
-
+        $operation = $this->getDeleteOperation($key);
         $compare = $this->getCompareForIf($key, $compareValue);
 
         return $this->requestIf($key, $operation, $compare, $returnNewValueOnFail);
@@ -270,6 +259,59 @@ class Client implements ClientInterface
         } else {
             return $response->getSucceeded();
         }
+    }
+
+    /**
+     * Creates RequestOp of Get operation for requestIf method
+     *
+     * @param string $key
+     * @return RequestOp
+     */
+    public function getGetOperation(string $key): RequestOp
+    {
+        $request = new RangeRequest();
+        $request->setKey($key);
+
+        $operation = new RequestOp();
+        $operation->setRequestRange($request);
+
+        return $operation;
+    }
+
+    /**
+     * Creates RequestOp of Put operation for requestIf method
+     *
+     * @param string $key
+     * @param string $value
+     * @return RequestOp
+     */
+    public function getPutOperation(string $key, string $value): RequestOp
+    {
+        $request = new PutRequest();
+        $request->setKey($key);
+        $request->setValue($value);
+
+        $operation = new RequestOp();
+        $operation->setRequestPut($request);
+
+        return $operation;
+    }
+
+    /**
+     * Creates RequestOp of Delete operation for requestIf method
+     *
+     * @param string $key
+     * @return RequestOp
+     */
+    public function getDeleteOperation(string $key): RequestOp
+    {
+        $request = new DeleteRangeRequest();
+        $request->setKey($key);
+
+        $operation = new RequestOp();
+        $operation->setRequestDeleteRange($request);
+
+        return $operation;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -266,13 +266,16 @@ class Client implements ClientInterface
      *
      * @param string $key
      * @param string $value
+     * @param int $leaseId
      * @return RequestOp
      */
-    public function getPutOperation(string $key, string $value): RequestOp
+    public function getPutOperation(string $key, string $value, int $leaseId = 0): RequestOp
     {
         $request = new PutRequest();
         $request->setKey($key);
         $request->setValue($value);
+        if($leaseId !== 0)
+            $request->setLease($leaseId);
 
         $operation = new RequestOp();
         $operation->setRequestPut($request);

--- a/src/Client.php
+++ b/src/Client.php
@@ -233,7 +233,7 @@ class Client implements ClientInterface
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      */
-    protected function requestIf(string $key, RequestOp $requestOperation, Compare $compare, bool $returnNewValueOnFail = false)
+    public function requestIf(string $key, RequestOp $requestOperation, Compare $compare, bool $returnNewValueOnFail = false)
     {
         $client = $this->getKvClient();
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -192,7 +192,7 @@ class Client implements ClientInterface
         $compare = $this->getCompareForIf($key, $compareValue);
         $failOperation = $this->getFailOperation($key, $returnNewValueOnFail);
 
-        $response = $this->requestIf($key, [$operation], $failOperation, [$compare]);
+        $response = $this->txnRequest($key, [$operation], $failOperation, [$compare]);
         return $this->getIfResponse($returnNewValueOnFail, $response);
     }
 
@@ -212,7 +212,7 @@ class Client implements ClientInterface
         $compare = $this->getCompareForIf($key, $compareValue);
         $failOperation = $this->getFailOperation($key, $returnNewValueOnFail);
 
-        $response = $this->requestIf($key, [$operation], $failOperation, [$compare]);
+        $response = $this->txnRequest($key, [$operation], $failOperation, [$compare]);
         return $this->getIfResponse($returnNewValueOnFail, $response);
     }
 
@@ -223,11 +223,10 @@ class Client implements ClientInterface
      * @param array $requestOperations operations to perform on success, array of RequestOp objects
      * @param array|null $failureOperations operations to perform on failure, array of RequestOp objects
      * @param array $compare array of Compare objects
-     * @param bool $returnNewValueOnFail
      * @return TxnResponse
      * @throws InvalidResponseStatusCodeException
      */
-    public function requestIf(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse
+    public function txnRequest(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse
     {
         $client = $this->getKvClient();
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -174,14 +174,14 @@ class Client implements ClientInterface
      * @param string $key
      * @param string $value The new value to set
      * @param string $compareValue The previous value to compare against
+     * @param bool $returnNewValueOnFail
      * @param string $compareOp can be '=', '!=', '>', '<'
      * @param int $compareTarget check constants in the CompareTarget class for available values
-     * @param bool $returnNewValueOnFail
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      * @throws \Exception
      */
-    public function putIf(string $key, string $value, string $compareValue = '0', string $compareOp = '=', int $compareTarget = CompareTarget::VALUE, bool $returnNewValueOnFail = false)
+    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE)
     {
         $request = new PutRequest();
         $request->setKey($key);
@@ -200,14 +200,14 @@ class Client implements ClientInterface
      *
      * @param string $key
      * @param string $compareValue The previous value to compare against
+     * @param bool $returnNewValueOnFail
      * @param string $compareOp can be '=', '!=', '>', '<'
      * @param int $compareTarget check constants in the CompareTarget class for available values
-     * @param bool $returnNewValueOnFail
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      * @throws \Exception
      */
-    public function deleteIf(string $key, string $compareValue = '0', string $compareOp = '=', int $compareTarget = CompareTarget::VALUE, bool $returnNewValueOnFail = false)
+    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE)
     {
         $request = new DeleteRangeRequest();
         $request->setKey($key);

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -3,6 +3,7 @@
 namespace Aternos\Etcd;
 
 use Aternos\Etcd\Exception\Status\InvalidResponseStatusCodeException;
+use Etcdserverpb\Compare\CompareTarget;
 
 /**
  * Interface ClientInterface
@@ -53,22 +54,27 @@ interface ClientInterface
      * Put $value if $key value matches $previousValue otherwise $returnNewValueOnFail
      *
      * @param string $key
-     * @param mixed $value The new value to set
-     * @param mixed $previousValue The previous value to compare against
+     * @param string $value The new value to set
+     * @param string $compareValue The previous value to compare against
+     * @param string $compareOp can be '=', '!=', '>', '<'
+     * @param int $compareTarget check constants in the CompareTarget class for available values
      * @param bool $returnNewValueOnFail
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      */
-    public function putIf(string $key, $value, $previousValue, bool $returnNewValueOnFail = false);
+    public function putIf(string $key, string $value, string $compareValue = '0', string $compareOp = '=', int $compareTarget = CompareTarget::VALUE, bool $returnNewValueOnFail = false);
 
     /**
      * Delete if $key value matches $previous value otherwise $returnNewValueOnFail
      *
      * @param string $key
-     * @param $previousValue
+     * @param string $compareValue The previous value to compare against
+     * @param string $compareOp can be '=', '!=', '>', '<'
+     * @param int $compareTarget check constants in the CompareTarget class for available values
      * @param bool $returnNewValueOnFail
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
+     * @throws \Exception
      */
-    public function deleteIf(string $key, $previousValue, bool $returnNewValueOnFail = false);
+    public function deleteIf(string $key, string $compareValue = '0', string $compareOp = '=', int $compareTarget = CompareTarget::VALUE, bool $returnNewValueOnFail = false);
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -86,4 +86,15 @@ interface ClientInterface
      * @throws InvalidResponseStatusCodeException
      */
     public function requestIf(string $key, RequestOp $requestOperation, Compare $compare, bool $returnNewValueOnFail = false);
+
+    /**
+     * Get an instance of Compare
+     *
+     * @param string $key
+     * @param string $value
+     * @param int $result see CompareResult class for available constants
+     * @param int $target check constants in the CompareTarget class for available values
+     * @return Compare
+     */
+    public function getCompare(string $key, string $value, int $result, int $target): Compare;
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -83,11 +83,10 @@ interface ClientInterface
      * @param array $requestOperations operations to perform on success, array of RequestOp objects
      * @param array|null $failureOperations operations to perform on failure, array of RequestOp objects
      * @param array $compare array of Compare objects
-     * @param bool $returnNewValueOnFail
      * @return TxnResponse
      * @throws InvalidResponseStatusCodeException
      */
-    public function requestIf(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse;
+    public function txnRequest(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse;
 
     /**
      * Get an instance of Compare

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -97,4 +97,29 @@ interface ClientInterface
      * @return Compare
      */
     public function getCompare(string $key, string $value, int $result, int $target): Compare;
+
+    /**
+     * Creates RequestOp of Get operation for requestIf method
+     *
+     * @param string $key
+     * @return RequestOp
+     */
+    public function getGetOperation(string $key): RequestOp;
+
+    /**
+     * Creates RequestOp of Put operation for requestIf method
+     *
+     * @param string $key
+     * @param string $value
+     * @return RequestOp
+     */
+    public function getPutOperation(string $key, string $value): RequestOp;
+
+    /**
+     * Creates RequestOp of Delete operation for requestIf method
+     *
+     * @param string $key
+     * @return RequestOp
+     */
+    public function getDeleteOperation(string $key): RequestOp;
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -3,6 +3,7 @@
 namespace Aternos\Etcd;
 
 use Aternos\Etcd\Exception\Status\InvalidResponseStatusCodeException;
+use Etcdserverpb\Compare\CompareResult;
 use Etcdserverpb\Compare\CompareTarget;
 
 /**
@@ -57,12 +58,12 @@ interface ClientInterface
      * @param string $value The new value to set
      * @param string $compareValue The previous value to compare against
      * @param bool $returnNewValueOnFail
-     * @param string $compareOp can be '=', '!=', '>', '<'
+     * @param int $compareOp see CompareResult class for available constants
      * @param int $compareTarget check constants in the CompareTarget class for available values
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      */
-    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE);
+    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE);
 
     /**
      * Delete if $key value matches $previous value otherwise $returnNewValueOnFail
@@ -70,11 +71,11 @@ interface ClientInterface
      * @param string $key
      * @param string $compareValue The previous value to compare against
      * @param bool $returnNewValueOnFail
-     * @param string $compareOp can be '=', '!=', '>', '<'
+     * @param int $compareOp see CompareResult class for available constants
      * @param int $compareTarget check constants in the CompareTarget class for available values
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      * @throws \Exception
      */
-    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE);
+    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE);
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -56,26 +56,22 @@ interface ClientInterface
      *
      * @param string $key
      * @param string $value The new value to set
-     * @param string $compareValue The previous value to compare against
+     * @param bool|string $compareValue The previous value to compare against
      * @param bool $returnNewValueOnFail
-     * @param int $compareOp see CompareResult class for available constants
-     * @param int $compareTarget check constants in the CompareTarget class for available values
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      */
-    public function putIf(string $key, string $value, string $compareValue, bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE);
+    public function putIf(string $key, string $value, $compareValue, bool $returnNewValueOnFail = false);
 
     /**
      * Delete if $key value matches $previous value otherwise $returnNewValueOnFail
      *
      * @param string $key
-     * @param string $compareValue The previous value to compare against
+     * @param bool|string $compareValue The previous value to compare against
      * @param bool $returnNewValueOnFail
-     * @param int $compareOp see CompareResult class for available constants
-     * @param int $compareTarget check constants in the CompareTarget class for available values
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      * @throws \Exception
      */
-    public function deleteIf(string $key, string $compareValue, bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE);
+    public function deleteIf(string $key, $compareValue, bool $returnNewValueOnFail = false);
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -79,13 +79,13 @@ interface ClientInterface
      * Execute $requestOperation if $key value matches $previous otherwise $returnNewValueOnFail
      *
      * @param string $key
-     * @param RequestOp $requestOperation
-     * @param Compare $compare
+     * @param array $requestOperations array of RequestOp objects
+     * @param array $compare array of Compare objects
      * @param bool $returnNewValueOnFail
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      */
-    public function requestIf(string $key, RequestOp $requestOperation, Compare $compare, bool $returnNewValueOnFail = false);
+    public function requestIf(string $key, array $requestOperations, array $compare, bool $returnNewValueOnFail = false);
 
     /**
      * Get an instance of Compare

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -56,25 +56,25 @@ interface ClientInterface
      * @param string $key
      * @param string $value The new value to set
      * @param string $compareValue The previous value to compare against
+     * @param bool $returnNewValueOnFail
      * @param string $compareOp can be '=', '!=', '>', '<'
      * @param int $compareTarget check constants in the CompareTarget class for available values
-     * @param bool $returnNewValueOnFail
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      */
-    public function putIf(string $key, string $value, string $compareValue = '0', string $compareOp = '=', int $compareTarget = CompareTarget::VALUE, bool $returnNewValueOnFail = false);
+    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE);
 
     /**
      * Delete if $key value matches $previous value otherwise $returnNewValueOnFail
      *
      * @param string $key
      * @param string $compareValue The previous value to compare against
+     * @param bool $returnNewValueOnFail
      * @param string $compareOp can be '=', '!=', '>', '<'
      * @param int $compareTarget check constants in the CompareTarget class for available values
-     * @param bool $returnNewValueOnFail
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      * @throws \Exception
      */
-    public function deleteIf(string $key, string $compareValue = '0', string $compareOp = '=', int $compareTarget = CompareTarget::VALUE, bool $returnNewValueOnFail = false);
+    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE);
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -5,6 +5,7 @@ namespace Aternos\Etcd;
 use Aternos\Etcd\Exception\Status\InvalidResponseStatusCodeException;
 use Etcdserverpb\Compare;
 use Etcdserverpb\RequestOp;
+use Etcdserverpb\TxnResponse;
 
 /**
  * Interface ClientInterface
@@ -79,13 +80,14 @@ interface ClientInterface
      * Execute $requestOperation if $key value matches $previous otherwise $returnNewValueOnFail
      *
      * @param string $key
-     * @param array $requestOperations array of RequestOp objects
+     * @param array $requestOperations operations to perform on success, array of RequestOp objects
+     * @param array|null $failureOperations operations to perform on failure, array of RequestOp objects
      * @param array $compare array of Compare objects
      * @param bool $returnNewValueOnFail
-     * @return bool|string
+     * @return TxnResponse
      * @throws InvalidResponseStatusCodeException
      */
-    public function requestIf(string $key, array $requestOperations, array $compare, bool $returnNewValueOnFail = false);
+    public function requestIf(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse;
 
     /**
      * Get an instance of Compare

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -63,7 +63,7 @@ interface ClientInterface
      * @return bool|string
      * @throws InvalidResponseStatusCodeException
      */
-    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE);
+    public function putIf(string $key, string $value, string $compareValue, bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE);
 
     /**
      * Delete if $key value matches $previous value otherwise $returnNewValueOnFail
@@ -77,5 +77,5 @@ interface ClientInterface
      * @throws InvalidResponseStatusCodeException
      * @throws \Exception
      */
-    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE);
+    public function deleteIf(string $key, string $compareValue, bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE);
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -113,9 +113,10 @@ interface ClientInterface
      *
      * @param string $key
      * @param string $value
+     * @param int $leaseId
      * @return RequestOp
      */
-    public function getPutOperation(string $key, string $value): RequestOp;
+    public function getPutOperation(string $key, string $value, int $leaseId = 0): RequestOp;
 
     /**
      * Creates RequestOp of Delete operation for requestIf method

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -3,8 +3,8 @@
 namespace Aternos\Etcd;
 
 use Aternos\Etcd\Exception\Status\InvalidResponseStatusCodeException;
-use Etcdserverpb\Compare\CompareResult;
-use Etcdserverpb\Compare\CompareTarget;
+use Etcdserverpb\Compare;
+use Etcdserverpb\RequestOp;
 
 /**
  * Interface ClientInterface
@@ -74,4 +74,16 @@ interface ClientInterface
      * @throws \Exception
      */
     public function deleteIf(string $key, $compareValue, bool $returnNewValueOnFail = false);
+
+    /**
+     * Execute $requestOperation if $key value matches $previous otherwise $returnNewValueOnFail
+     *
+     * @param string $key
+     * @param RequestOp $requestOperation
+     * @param Compare $compare
+     * @param bool $returnNewValueOnFail
+     * @return bool|string
+     * @throws InvalidResponseStatusCodeException
+     */
+    public function requestIf(string $key, RequestOp $requestOperation, Compare $compare, bool $returnNewValueOnFail = false);
 }

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -3,6 +3,7 @@
 namespace Aternos\Etcd;
 
 use Aternos\Etcd\Exception\InvalidClientException;
+use Etcdserverpb\Compare\CompareTarget;
 use Flexihash\Flexihash;
 
 /**
@@ -112,17 +113,17 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function putIf(string $key, $value, $previousValue, bool $returnNewValueOnFail = false)
+    public function putIf(string $key, string $value, string $compareValue = '0', string $compareOp = '=', int $compareTarget = CompareTarget::VALUE, bool $returnNewValueOnFail = false)
     {
-        return $this->getClientFromKey($key)->putIf($key, $value, $previousValue, $returnNewValueOnFail);
+        return $this->getClientFromKey($key)->putIf($key, $value, $compareValue, $compareOp, $compareTarget, $returnNewValueOnFail);
     }
 
     /**
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function deleteIf(string $key, $previousValue, bool $returnNewValueOnFail = false)
+    public function deleteIf(string $key, string $compareValue = '0', string $compareOp = '=', int $compareTarget = CompareTarget::VALUE, bool $returnNewValueOnFail = false)
     {
-        return $this->getClientFromKey($key)->deleteIf($key, $previousValue, $returnNewValueOnFail);
+        return $this->getClientFromKey($key)->deleteIf($key, $compareValue, $compareOp, $compareTarget, $returnNewValueOnFail);
     }
 }

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -3,8 +3,8 @@
 namespace Aternos\Etcd;
 
 use Aternos\Etcd\Exception\InvalidClientException;
-use Etcdserverpb\Compare\CompareResult;
-use Etcdserverpb\Compare\CompareTarget;
+use Etcdserverpb\Compare;
+use Etcdserverpb\RequestOp;
 use Flexihash\Flexihash;
 
 /**
@@ -126,5 +126,14 @@ class ShardedClient implements ClientInterface
     public function deleteIf(string $key, $compareValue, bool $returnNewValueOnFail = false)
     {
         return $this->getClientFromKey($key)->deleteIf($key, $compareValue, $returnNewValueOnFail);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Flexihash\Exception
+     */
+    public function requestIf(string $key, RequestOp $requestOperation, Compare $compare, bool $returnNewValueOnFail = false)
+    {
+        return $this->getClientFromKey($key)->requestIf($key, $requestOperation, $compare, $returnNewValueOnFail);
     }
 }

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -113,17 +113,17 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function putIf(string $key, string $value, string $compareValue = '0', string $compareOp = '=', int $compareTarget = CompareTarget::VALUE, bool $returnNewValueOnFail = false)
+    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE)
     {
-        return $this->getClientFromKey($key)->putIf($key, $value, $compareValue, $compareOp, $compareTarget, $returnNewValueOnFail);
+        return $this->getClientFromKey($key)->putIf($key, $value, $compareValue, $returnNewValueOnFail, $compareOp, $compareTarget);
     }
 
     /**
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function deleteIf(string $key, string $compareValue = '0', string $compareOp = '=', int $compareTarget = CompareTarget::VALUE, bool $returnNewValueOnFail = false)
+    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE)
     {
-        return $this->getClientFromKey($key)->deleteIf($key, $compareValue, $compareOp, $compareTarget, $returnNewValueOnFail);
+        return $this->getClientFromKey($key)->deleteIf($key, $compareValue, $returnNewValueOnFail, $compareOp, $compareTarget);
     }
 }

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -114,7 +114,7 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
+    public function putIf(string $key, string $value, string $compareValue, bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
     {
         return $this->getClientFromKey($key)->putIf($key, $value, $compareValue, $returnNewValueOnFail, $compareOp, $compareTarget);
     }
@@ -123,7 +123,7 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
+    public function deleteIf(string $key, string $compareValue, bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
     {
         return $this->getClientFromKey($key)->deleteIf($key, $compareValue, $returnNewValueOnFail, $compareOp, $compareTarget);
     }

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -133,9 +133,9 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function requestIf(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse
+    public function txnRequest(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse
     {
-        return $this->getClientFromKey($key)->requestIf($key, $requestOperations, $failureOperations, $compare);
+        return $this->getClientFromKey($key)->txnRequest($key, $requestOperations, $failureOperations, $compare);
     }
 
     /**

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -145,4 +145,31 @@ class ShardedClient implements ClientInterface
     {
         return $this->getClientFromKey($key)->getCompare($key, $value, $result, $target);
     }
+
+    /**
+     * @inheritDoc
+     * @throws \Flexihash\Exception
+     */
+    public function getGetOperation(string $key): RequestOp
+    {
+        return $this->getClientFromKey($key)->getGetOperation($key);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Flexihash\Exception
+     */
+    public function getPutOperation(string $key, string $value): RequestOp
+    {
+        return $this->getClientFromKey($key)->getPutOperation($key, $value);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Flexihash\Exception
+     */
+    public function getDeleteOperation(string $key): RequestOp
+    {
+        return $this->getClientFromKey($key)->getDeleteOperation($key);
+    }
 }

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -114,17 +114,17 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function putIf(string $key, string $value, string $compareValue, bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
+    public function putIf(string $key, string $value, $compareValue, bool $returnNewValueOnFail = false)
     {
-        return $this->getClientFromKey($key)->putIf($key, $value, $compareValue, $returnNewValueOnFail, $compareOp, $compareTarget);
+        return $this->getClientFromKey($key)->putIf($key, $value, $compareValue, $returnNewValueOnFail);
     }
 
     /**
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function deleteIf(string $key, string $compareValue, bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
+    public function deleteIf(string $key, $compareValue, bool $returnNewValueOnFail = false)
     {
-        return $this->getClientFromKey($key)->deleteIf($key, $compareValue, $returnNewValueOnFail, $compareOp, $compareTarget);
+        return $this->getClientFromKey($key)->deleteIf($key, $compareValue, $returnNewValueOnFail);
     }
 }

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -5,6 +5,7 @@ namespace Aternos\Etcd;
 use Aternos\Etcd\Exception\InvalidClientException;
 use Etcdserverpb\Compare;
 use Etcdserverpb\RequestOp;
+use Etcdserverpb\TxnResponse;
 use Flexihash\Flexihash;
 
 /**
@@ -132,9 +133,9 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function requestIf(string $key, array $requestOperations, array $compare, bool $returnNewValueOnFail = false)
+    public function requestIf(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse
     {
-        return $this->getClientFromKey($key)->requestIf($key, $requestOperations, $compare, $returnNewValueOnFail);
+        return $this->getClientFromKey($key)->requestIf($key, $requestOperations, $failureOperations, $compare);
     }
 
     /**

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -136,4 +136,13 @@ class ShardedClient implements ClientInterface
     {
         return $this->getClientFromKey($key)->requestIf($key, $requestOperation, $compare, $returnNewValueOnFail);
     }
+
+    /**
+     * @inheritDoc
+     * @throws \Flexihash\Exception
+     */
+    public function getCompare(string $key, string $value, int $result, int $target): Compare
+    {
+        return $this->getClientFromKey($key)->getCompare($key, $value, $result, $target);
+    }
 }

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -160,9 +160,9 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function getPutOperation(string $key, string $value): RequestOp
+    public function getPutOperation(string $key, string $value, int $leaseId = 0): RequestOp
     {
-        return $this->getClientFromKey($key)->getPutOperation($key, $value);
+        return $this->getClientFromKey($key)->getPutOperation($key, $value, $leaseId);
     }
 
     /**

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -3,6 +3,7 @@
 namespace Aternos\Etcd;
 
 use Aternos\Etcd\Exception\InvalidClientException;
+use Etcdserverpb\Compare\CompareResult;
 use Etcdserverpb\Compare\CompareTarget;
 use Flexihash\Flexihash;
 
@@ -113,7 +114,7 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE)
+    public function putIf(string $key, string $value, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
     {
         return $this->getClientFromKey($key)->putIf($key, $value, $compareValue, $returnNewValueOnFail, $compareOp, $compareTarget);
     }
@@ -122,7 +123,7 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, string $compareOp = '=', int $compareTarget = CompareTarget::VALUE)
+    public function deleteIf(string $key, string $compareValue = '0', bool $returnNewValueOnFail = false, int $compareOp = CompareResult::EQUAL, int $compareTarget = CompareTarget::VALUE)
     {
         return $this->getClientFromKey($key)->deleteIf($key, $compareValue, $returnNewValueOnFail, $compareOp, $compareTarget);
     }

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -132,9 +132,9 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws \Flexihash\Exception
      */
-    public function requestIf(string $key, RequestOp $requestOperation, Compare $compare, bool $returnNewValueOnFail = false)
+    public function requestIf(string $key, array $requestOperations, array $compare, bool $returnNewValueOnFail = false)
     {
-        return $this->getClientFromKey($key)->requestIf($key, $requestOperation, $compare, $returnNewValueOnFail);
+        return $this->getClientFromKey($key)->requestIf($key, $requestOperations, $compare, $returnNewValueOnFail);
     }
 
     /**


### PR DESCRIPTION
Added support for custom comparison operation and target. 

I tried to implement this same way as it is implemented the original Golang library.

Unfortunately I had to change ClientInterface as well. It could be implemented with adding new methods like 'putIf2' and 'deleteIf2' to the interface, but it would be dirty and not worth it in my opinion.