### PR TITLE
Removed extra unused parameter $key from the txnRequest method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -204,7 +204,7 @@ class Client implements ClientInterface
         $compare = $this->getCompareForIf($key, $compareValue);
         $failOperation = $this->getFailOperation($key, $returnNewValueOnFail);
 
-        $response = $this->txnRequest($key, [$operation], $failOperation, [$compare]);
+        $response = $this->txnRequest([$operation], $failOperation, [$compare]);
         return $this->getIfResponse($returnNewValueOnFail, $response);
     }
 
@@ -224,7 +224,7 @@ class Client implements ClientInterface
         $compare = $this->getCompareForIf($key, $compareValue);
         $failOperation = $this->getFailOperation($key, $returnNewValueOnFail);
 
-        $response = $this->txnRequest($key, [$operation], $failOperation, [$compare]);
+        $response = $this->txnRequest([$operation], $failOperation, [$compare]);
         return $this->getIfResponse($returnNewValueOnFail, $response);
     }
 
@@ -291,16 +291,15 @@ class Client implements ClientInterface
     }
 
     /**
-     * Execute $requestOperation if $key value matches $previous otherwise $returnNewValueOnFail
+     * Execute $requestOperations if Compare succeeds, execute $failureOperations otherwise if defined
      *
-     * @param string $key
      * @param array $requestOperations operations to perform on success, array of RequestOp objects
      * @param array|null $failureOperations operations to perform on failure, array of RequestOp objects
      * @param array $compare array of Compare objects
      * @return TxnResponse
      * @throws InvalidResponseStatusCodeException
      */
-    public function txnRequest(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse
+    public function txnRequest(array $requestOperations, ?array $failureOperations, array $compare): TxnResponse
     {
         $client = $this->getKvClient();
 

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -78,16 +78,15 @@ interface ClientInterface
     public function deleteIf(string $key, $compareValue, bool $returnNewValueOnFail = false);
 
     /**
-     * Execute $requestOperation if $key value matches $previous otherwise $returnNewValueOnFail
+     * Execute $requestOperations if Compare succeeds, execute $failureOperations otherwise if defined
      *
-     * @param string $key
      * @param array $requestOperations operations to perform on success, array of RequestOp objects
      * @param array|null $failureOperations operations to perform on failure, array of RequestOp objects
      * @param array $compare array of Compare objects
      * @return TxnResponse
      * @throws InvalidResponseStatusCodeException
      */
-    public function txnRequest(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse;
+    public function txnRequest(array $requestOperations, ?array $failureOperations, array $compare): TxnResponse;
 
     /**
      * Get an instance of Compare

--- a/src/ShardedClient.php
+++ b/src/ShardedClient.php
@@ -145,9 +145,9 @@ class ShardedClient implements ClientInterface
      * @inheritDoc
      * @throws Exception
      */
-    public function txnRequest(string $key, array $requestOperations, ?array $failureOperations, array $compare): TxnResponse
+    public function txnRequest(array $requestOperations, ?array $failureOperations, array $compare): TxnResponse
     {
-        return $this->getClientFromKey($key)->txnRequest($key, $requestOperations, $failureOperations, $compare);
+        return $this->getRandomClient()->txnRequest($requestOperations, $failureOperations, $compare);
     }
 
     /**


### PR DESCRIPTION
`$key` param in the `txnRequest` method is leftover from the previous (now in-existent) method `requestIf`.