### PR TITLE
Etcd node failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,24 @@ $shardedClient = new Aternos\Etcd\ShardedClient($clients);
 $shardedClient->put("key", "value");
 $shardedClient->get("key");
 ```
+
+### Failover client
+
+- automatically and transparently fails-over in case etcd host fails 
+```php
+<?php
+
+$clients = [
+    new Aternos\Etcd\Client("hostA:2379"),
+    new Aternos\Etcd\Client("hostB:2379"),
+    new Aternos\Etcd\Client("hostC:2379")
+];
+$failoverClient = new Aternos\Etcd\FailoverClient($clients);
+
+// set 60 seconds as a hold-off period between another connection attempt to the failing host 
+// default is 120 seconds
+// failing host is being remembered within FailoverClient object instance 
+$failoverClient->setHoldoffTime(60);
+$failoverClient->put("key", "value");
+$failoverClient->get("key");
+```

--- a/src/Client.php
+++ b/src/Client.php
@@ -294,9 +294,9 @@ class Client implements ClientInterface
     /**
      * Execute $requestOperations if Compare succeeds, execute $failureOperations otherwise if defined
      *
-     * @param array $requestOperations operations to perform on success, array of RequestOp objects
-     * @param array|null $failureOperations operations to perform on failure, array of RequestOp objects
-     * @param array $compare array of Compare objects
+     * @param RequestOp[] $requestOperations operations to perform on success, array of RequestOp objects
+     * @param RequestOp[]|null $failureOperations operations to perform on failure, array of RequestOp objects
+     * @param Compare[] $compare array of Compare objects
      * @return TxnResponse
      * @throws InvalidResponseStatusCodeException
      */

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 namespace Aternos\Etcd;
 
+use Aternos\Etcd\Exception\NoResponseException;
 use Aternos\Etcd\Exception\Status\InvalidResponseStatusCodeException;
 use Aternos\Etcd\Exception\Status\ResponseStatusCodeExceptionFactory;
 use Etcdserverpb\AuthClient;
@@ -271,7 +272,7 @@ class Client implements ClientInterface
      * @param int $leaseID
      * @return int lease TTL
      * @throws InvalidResponseStatusCodeException
-     * @throws Exception
+     * @throws NoResponseException
      */
     public function refreshLease(int $leaseID)
     {
@@ -286,7 +287,7 @@ class Client implements ClientInterface
         $response = $leaseBidi->read();
         $leaseBidi->cancel();
         if($response === null || empty($response->getID()) || (int)$response->getID() !== $leaseID)
-            throw new Exception('Could not refresh lease ID: ' . $leaseID);
+            throw new NoResponseException('Could not refresh lease ID: ' . $leaseID);
 
         return (int)$response->getTTL();
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -285,7 +285,7 @@ class Client implements ClientInterface
         /** @var LeaseKeepAliveResponse $response */
         $response = $leaseBidi->read();
         $leaseBidi->cancel();
-        if(empty($response->getID()) || (int)$response->getID() !== $leaseID)
+        if($response === null || empty($response->getID()) || (int)$response->getID() !== $leaseID)
             throw new Exception('Could not refresh lease ID: ' . $leaseID);
 
         return (int)$response->getTTL();

--- a/src/Exception/InvalidLeaseException.php
+++ b/src/Exception/InvalidLeaseException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Aternos\Etcd\Exception;
+
+/**
+ * Class InvalidLeaseException
+ *
+ * @package Aternos\Etcd\Exception
+ */
+class InvalidLeaseException extends \Exception
+{
+
+}

--- a/src/Exception/NoClientAvailableException.php
+++ b/src/Exception/NoClientAvailableException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Aternos\Etcd\Exception;
+
+/**
+ * Class NoClientAvailableException
+ *
+ * @package Aternos\Etcd\Exception
+ */
+class NoClientAvailableException extends \Exception
+{
+
+}

--- a/src/Exception/NoResponseException.php
+++ b/src/Exception/NoResponseException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Aternos\Etcd\Exception;
+
+/**
+ * Class NoResponseException
+ *
+ * @package Aternos\Etcd\Exception
+ */
+class NoResponseException extends \Exception
+{
+
+}

--- a/src/FailoverClient.php
+++ b/src/FailoverClient.php
@@ -297,6 +297,22 @@ class FailoverClient implements ClientInterface
     }
 
     /**
+     * Returns true if method is known as local meaning it does not call remote etcd server
+     *
+     * @param string $methodName
+     * @return bool
+     */
+    protected static function isLocalCall(string $methodName): bool
+    {
+        $local = [
+            'getCompare' => true, 'getDeleteOperation' => true, 'getPutOperation' => true,
+            'getGetOperation' => true, 'getResponses' => true, 'getHostname' => true
+        ];
+
+        return isset($local[$methodName]);
+    }
+
+    /**
      * @param string $name Client method
      * @param mixed $arguments method's arguments
      * @return mixed
@@ -308,7 +324,7 @@ class FailoverClient implements ClientInterface
         while ($client = $this->getClient()) {
             try {
                 $result = $client->$name(...$arguments);
-                if (isset($this->retry[$client->getHostname()]))
+                if (isset($this->retry[$client->getHostname()]) && !static::isLocalCall($name))
                     unset($this->retry[$client->getHostname()]);
 
                 return $result;

--- a/src/FailoverClient.php
+++ b/src/FailoverClient.php
@@ -14,10 +14,13 @@ use Etcdserverpb\TxnResponse;
 /**
  * Class FailoverClient
  *
- * Using FIFO structure. Client is being used, until it fails. When it fails,
+ * Using random-based load-balancing by default.
+ * Client is being used, until it fails when LB turned off. When Client fails,
  * it's moved to the end of the array and first Client on top of the array is being used.
- * On top of it each Client gets fail timestamp in case it fails. We are not using such client
- * until hold-off period passes. If no usable Client is left, \Exception is thrown.
+ * When Client's remote call fails, Client's fail counter increases.
+ * On top of it each Client gets fail timestamp in case it reaches max retry value (default 3).
+ * We are not using such client until hold-off period passes (default 120s).
+ * If no usable Client is left, NoClientAvailableException is thrown.
  *
  * @package Aternos\Etcd
  */

--- a/src/FailoverClient.php
+++ b/src/FailoverClient.php
@@ -297,7 +297,7 @@ class FailoverClient implements ClientInterface
 
                 return $result;
             } /** @noinspection PhpRedundantCatchClauseInspection */
-            catch (UnavailableException | DeadlineExceededException $e) {
+            catch (UnavailableException | DeadlineExceededException | NoResponseException $e) {
                 $this->failCurrentClient();
             }
         }

--- a/src/FailoverClient.php
+++ b/src/FailoverClient.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Aternos\Etcd;
+
+use Aternos\Etcd\Exception\InvalidClientException;
+use Aternos\Etcd\Exception\Status\InvalidResponseStatusCodeException;
+use Etcdserverpb\Compare;
+use Etcdserverpb\RequestOp;
+use Etcdserverpb\TxnResponse;
+
+/**
+ * Class FailoverClient
+ *
+ * Using FIFO structure. Client is being used, until it fails. When it fails,
+ * it's moved to the end of the array and first Client on top of the array is being used.
+ * On top of it each Client gets fail timestamp in case it fails. We are not using such client
+ * until hold-off period passes. If no usable Client is left, \Exception is thrown.
+ *
+ * @method string getHostname()
+ * @method put(string $key, $value, bool $prevKv = false, int $leaseID = 0, bool $ignoreLease = false, bool $ignoreValue = false)
+ * @method get(string $key)
+ * @method delete(string $key)
+ * @method putIf(string $key, string $value, $compareValue, bool $returnNewValueOnFail = false)
+ * @method deleteIf(string $key, $compareValue, bool $returnNewValueOnFail = false)
+ * @method TxnResponse txnRequest(array $requestOperations, ?array $failureOperations, array $compare)
+ * @method Compare getCompare(string $key, string $value, int $result, int $target)
+ * @method RequestOp getGetOperation(string $key)
+ * @method RequestOp getPutOperation(string $key, string $value, int $leaseId = 0)
+ * @method RequestOp getDeleteOperation(string $key)
+ * @method int getLeaseID(int $ttl)
+ * @method revokeLeaseID(int $leaseID)
+ * @method int refreshLease(int $leaseID)
+ * @method array getResponses(TxnResponse $txnResponse, ?string $type = null, bool $simpleArray = false)
+ *
+ * @package Aternos\Etcd
+ */
+class FailoverClient
+{
+    /**
+     * How long to keep Client marked as failed and evicted from active client's list
+     * in seconds
+     *
+     * @var int
+     */
+    protected $holdoffTime = 120;
+
+    /**
+     * @var ClientInterface[]
+     */
+    protected $clients = [];
+
+    /**
+     * FailoverClient constructor.
+     *
+     * @param ClientInterface[] $clients
+     * @throws InvalidClientException
+     */
+    public function __construct(array $clients)
+    {
+        foreach ($clients as $client) {
+            if (!$client instanceof ClientInterface) {
+                throw new InvalidClientException("Invalid client in the client list");
+            }
+            $this->addClient($client);
+        }
+    }
+
+    /**
+     * @param string $name Client method
+     * @param mixed $arguments method's arguments
+     * @return mixed
+     * @throws \Exception when there is no available etcd client
+     */
+    public function __call(string $name, $arguments)
+    {
+        while ($client = $this->getClient()) {
+            try {
+                return $client->$name(...$arguments);
+            } /** @noinspection PhpRedundantCatchClauseInspection */
+            catch (InvalidResponseStatusCodeException $e) {
+                $this->failCurrentClient();
+            }
+        }
+        throw new \Exception('Failed to call: ' . $name);
+    }
+
+    /**
+     * Change holdoff period for failing client
+     *
+     * @param int $holdoffTime
+     */
+    public function setHoldoffTime(int $holdoffTime)
+    {
+        $this->holdoffTime = $holdoffTime;
+    }
+
+    /**
+     * @param ClientInterface $client
+     */
+    protected function addClient(ClientInterface $client)
+    {
+        $this->clients[] = ['client' => $client];
+    }
+
+    protected function failCurrentClient()
+    {
+        $this->clients[0]['fail'] = time();
+        $t = array_shift($this->clients);
+        $this->clients[] = $t;
+    }
+
+    /**
+     * @return ClientInterface
+     * @throws \Exception
+     */
+    protected function getClient(): ClientInterface
+    {
+        if (!isset($this->clients[0]['fail']) || ((time() - $this->clients[0]['fail']) > $this->holdoffTime))
+            return $this->clients[0]['client'];
+
+        throw new \Exception('Could not get any working etcd server');
+    }
+}

--- a/src/FailoverClient.php
+++ b/src/FailoverClient.php
@@ -122,12 +122,21 @@ class FailoverClient
 
     /**
      * @return ClientInterface
+     */
+    protected function getRandomClient(): ClientInterface
+    {
+        $rndIndex = array_rand($this->clients);
+        return $this->clients[$rndIndex];
+    }
+
+    /**
+     * @return ClientInterface
      * @throws \Exception
      */
     protected function getClient(): ClientInterface
     {
-        if (isset($this->clients[0]))
-            return $this->clients[0];
+        if (count($this->clients) > 0)
+            return ($this->balancing) ? $this->getRandomClient() : $this->clients[0];
 
         if ((time() - $this->failedClients[0]['time']) > $this->holdoffTime) {
             $t = array_shift($this->failedClients);

--- a/src/FailoverClient.php
+++ b/src/FailoverClient.php
@@ -4,7 +4,8 @@ namespace Aternos\Etcd;
 
 use Aternos\Etcd\Exception\InvalidClientException;
 use Aternos\Etcd\Exception\NoClientAvailableException;
-use Aternos\Etcd\Exception\Status\InvalidResponseStatusCodeException;
+use Aternos\Etcd\Exception\Status\DeadlineExceededException;
+use Aternos\Etcd\Exception\Status\UnavailableException;
 use Etcdserverpb\Compare;
 use Etcdserverpb\RequestOp;
 use Etcdserverpb\TxnResponse;
@@ -89,7 +90,7 @@ class FailoverClient
             try {
                 return $client->$name(...$arguments);
             } /** @noinspection PhpRedundantCatchClauseInspection */
-            catch (InvalidResponseStatusCodeException $e) {
+            catch (UnavailableException | DeadlineExceededException $e) {
                 $this->failCurrentClient();
             }
         }

--- a/src/FailoverClient.php
+++ b/src/FailoverClient.php
@@ -280,18 +280,17 @@ class FailoverClient implements ClientInterface
      */
     protected function getClient(): ClientInterface
     {
-        if ($client = $this->getFirstClient())
-            return ($this->balancing) ? $this->getRandomClient() : $client;
-
         foreach ($this->failedClients as $failedClient) {
             if ((time() - $failedClient['time']) > $this->holdoffTime) {
                 $c = array_shift($this->failedClients);
                 /** @var ClientInterface $client */
                 $client = $c['client'];
                 $this->clients[$client->getHostname()] = $client;
-                return $client;
             }
         }
+
+        if ($client = $this->getFirstClient())
+            return ($this->balancing) ? $this->getRandomClient() : $client;
 
         throw new NoClientAvailableException('Could not get any working etcd server');
     }

--- a/src/FailoverClient.php
+++ b/src/FailoverClient.php
@@ -303,7 +303,6 @@ class FailoverClient implements ClientInterface
      * @param bool $isLocalCall defines whether called method calls remote etcd endpoint
      * @return mixed
      * @throws NoClientAvailableException when there is no available etcd client
-     * @throws \Exception
      */
     protected function callClientMethod(string $name, bool $isLocalCall, ...$arguments)
     {
@@ -319,6 +318,5 @@ class FailoverClient implements ClientInterface
                 $this->failClient($client);
             }
         }
-        throw new \Exception('Failed to call: ' . $name);
     }
 }

--- a/src/FailoverClient.php
+++ b/src/FailoverClient.php
@@ -3,6 +3,7 @@
 namespace Aternos\Etcd;
 
 use Aternos\Etcd\Exception\InvalidClientException;
+use Aternos\Etcd\Exception\NoClientAvailableException;
 use Aternos\Etcd\Exception\Status\InvalidResponseStatusCodeException;
 use Etcdserverpb\Compare;
 use Etcdserverpb\RequestOp;
@@ -79,7 +80,8 @@ class FailoverClient
      * @param string $name Client method
      * @param mixed $arguments method's arguments
      * @return mixed
-     * @throws \Exception when there is no available etcd client
+     * @throws NoClientAvailableException when there is no available etcd client
+     * @throws \Exception
      */
     public function __call(string $name, $arguments)
     {
@@ -131,7 +133,7 @@ class FailoverClient
 
     /**
      * @return ClientInterface
-     * @throws \Exception
+     * @throws NoClientAvailableException
      */
     protected function getClient(): ClientInterface
     {
@@ -144,6 +146,6 @@ class FailoverClient
             return $this->clients[0];
         }
 
-        throw new \Exception('Could not get any working etcd server');
+        throw new NoClientAvailableException('Could not get any working etcd server');
     }
 }


### PR DESCRIPTION
Added client fail-over. Simple yet working solution to transparently handle failed etcd node by re-trying request on the another available etcd host. 